### PR TITLE
Adding #mu-custom-editor-extra

### DIFF
--- a/src/scripts/controllers/assignment-controller.js
+++ b/src/scripts/controllers/assignment-controller.js
@@ -218,6 +218,7 @@ angular
       };
 
       $scope.renderCustomEditor = false;
+      $scope.lastSolutionExtra = assignment.exercise.extra;
       $scope.lastSolutionContent = _.get(assignment.diffs.last(), 'right.content', '');
       $timeout(() => $scope.renderCustomEditor = true);
 

--- a/src/scripts/directives/custom-editor-directive.js
+++ b/src/scripts/directives/custom-editor-directive.js
@@ -9,6 +9,7 @@ angular
       scope: {
         language: '=',
         content: '=',
+        extra: '=',
         extraAttributes: '='
       },
       controller: ($scope) => {

--- a/src/views/assignment.jade
+++ b/src/views/assignment.jade
@@ -47,7 +47,7 @@
 
                   div(ng-if="hasSubmissions()")
                     div(ng-if='assignment.exercise.usesCustomEditor()')
-                      custom-editor(ng-if="renderCustomEditor", language="assignment.guide.language", content='lastSolutionContent', extra-attributes="'read-only=true'")
+                      custom-editor(ng-if="renderCustomEditor", language="assignment.guide.language", content='lastSolutionContent', extra='lastSolutionExtra', extra-attributes="'read-only=true'")
                     div(ng-if='assignment.exercise.usesFreeFormEditor()')
                       div(ng-bind-html='assignment.exercise.trustedFreeFormEditorSource()')
                     div(ng-if='!assignment.exercise.usesCustomEditor() && !assignment.exercise.usesFreeFormEditor()')

--- a/src/views/directives/custom-editor.jade
+++ b/src/views/directives/custom-editor.jade
@@ -1,1 +1,2 @@
 input#mu-custom-editor-value.ng-hide(ng-model="content")
+input#mu-custom-editor-extra.ng-hide(ng-model="extra")


### PR DESCRIPTION
This PR fixes the errors where the extra code of gobstones exercises doesn't load and causes a crash on the blockly solutions that depend on teacher's code.