### PR TITLE
Gobstones fixes

### DIFF
--- a/src/scripts/mulyfill.js
+++ b/src/scripts/mulyfill.js
@@ -18,3 +18,5 @@ mumuki.kids = {
     // nothing
   }
 };
+
+mumuki.assetsLoadedFor = (_) => {};

--- a/src/scripts/services/scroll-service.js
+++ b/src/scripts/services/scroll-service.js
@@ -6,13 +6,17 @@ angular
     const FIXED_OFFSET = 28;
 
     this.bottom = (cssClass) => {
-      $timeout(() => $(cssClass).scrollTop($(cssClass)[0].scrollHeight));
+      $timeout(() => $(cssClass).scrollTop(this.currentScrollHeight(cssClass)));
     };
 
     this.holdContent = (cssClass, callback) => {
-      const currentHeight = $(cssClass)[0].scrollHeight;
+      const currentHeight = this.currentScrollHeight(cssClass);
       callback();
       $timeout(() => $(cssClass).scrollTop($(cssClass)[0].scrollHeight - currentHeight - FIXED_OFFSET));
     }
 
+    this.currentScrollHeight = (cssClass) => {
+      const $element = $(cssClass)[0];
+      return $element ? $element.scrollHeight : 0;
+    };
   });


### PR DESCRIPTION
## :dart: Goal

This PR fixes miscellaneous gobstones-block issues.   

## :memo: Details

This PR fixes the following classroom errors: 

#### `Uncaught TypeError: mumuki.assetsLoadedFor is not a function`

![Screenshot_2020-10-20_18-28-18](https://user-images.githubusercontent.com/677436/96646235-35e51500-1302-11eb-8746-004dd1076d99.png)

### `TypeError: Cannot read property 'scrollHeight' of undefined`

This is not actually related to gobstones, but I found it annoying since i wanted to show a clear errors view :smile: 

![Screenshot_2020-10-20_18-54-14](https://user-images.githubusercontent.com/677436/96648433-ba856280-1305-11eb-9211-5c6982f4574e.png)

## :camera: Screenshots

Finally, no errors: 

![Screenshot_2020-10-20_18-57-13](https://user-images.githubusercontent.com/677436/96648742-32ec2380-1306-11eb-9bae-fa41c855de29.png)

## :warning: Warnings

Depends on https://github.com/mumuki/mumuki-gobstones-runner/pull/207
